### PR TITLE
use OpenSSL instead of Mcrypt

### DIFF
--- a/callback/pkcs7Encoder.php
+++ b/callback/pkcs7Encoder.php
@@ -58,110 +58,95 @@ class PKCS7Encoder
  */
 class Prpcrypt
 {
-	public $key;
+    public $key = null;
+    public $iv = null;
 
-	function __construct($k)
-	{
-		$this->key = base64_decode($k . "=");
-	}
+    /**
+     * Prpcrypt constructor.
+     * @param $k
+     */
+    public function __construct($k)
+    {
+        $this->key = base64_decode($k . '=');
+        $this->iv  = substr($this->key, 0, 16);
 
-	/**
-	 * 对明文进行加密
-	 * @param string $text 需要加密的明文
-	 * @return string 加密后的密文
-	 */
-	public function encrypt($text, $corpid)
-	{
+    }
 
-		try {
-			//获得16位随机字符串，填充到明文之前
-			$random = $this->getRandomStr();
-			$text = $random . pack("N", strlen($text)) . $text . $corpid;
-			// 网络字节序
-			$size = mcrypt_get_block_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
-			$module = mcrypt_module_open(MCRYPT_RIJNDAEL_128, '', MCRYPT_MODE_CBC, '');
-			$iv = substr($this->key, 0, 16);
-			//使用自定义的填充方式对明文进行补位填充
-			$pkc_encoder = new PKCS7Encoder;
-			$text = $pkc_encoder->encode($text);
-			mcrypt_generic_init($module, $this->key, $iv);
-			//加密
-			$encrypted = mcrypt_generic($module, $text);
-			mcrypt_generic_deinit($module);
-			mcrypt_module_close($module);
+    /**
+     * 加密
+     *
+     * @param $text
+     * @param $corpid
+     * @return array
+     */
+    public function encrypt($text, $corpid)
+    {
+        try {
+            //拼接
+            $text = $this->getRandomStr() . pack('N', strlen($text)) . $text . $corpid;
+            //添加PKCS#7填充
+            $pkc_encoder = new PKCS7Encoder;
+            $text        = $pkc_encoder->encode($text);
+            //加密
+            $encrypted = openssl_encrypt($text, 'AES-256-CBC', $this->key, OPENSSL_ZERO_PADDING, $this->iv);
+            return [ErrorCode::$OK, $encrypted];
+        } catch (Exception $e) {
+            print $e;
+            return [MyErrorCode::$EncryptAESError, null];
+        }
+    }
 
-			//print(base64_encode($encrypted));
-			//使用BASE64对加密后的字符串进行编码
-			return array(ErrorCode::$OK, base64_encode($encrypted));
-		} catch (Exception $e) {
-			print $e;
-			return array(ErrorCode::$EncryptAESError, null);
-		}
-	}
+    /**
+     * 解密
+     *
+     * @param $encrypted
+     * @param $corpid
+     * @return array
+     */
+    public function decrypt($encrypted, $corpid)
+    {
+        try {
+            //解密
+            $decrypted = openssl_decrypt($encrypted, 'AES-256-CBC', $this->key, OPENSSL_ZERO_PADDING, $this->iv);
+        } catch (Exception $e) {
+            return [ErrorCode::$DecryptAESError, null];
+        }
+        try {
+            //删除PKCS#7填充
+            $pkc_encoder = new PKCS7Encoder;
+            $result      = $pkc_encoder->decode($decrypted);
+            if (strlen($result) < 16) {
+                return [];
+            }
+            //拆分
+            $content     = substr($result, 16, strlen($result));
+            $len_list    = unpack('N', substr($content, 0, 4));
+            $xml_len     = $len_list[1];
+            $xml_content = substr($content, 4, $xml_len);
+            $from_corpid = substr($content, $xml_len + 4);
+        } catch (Exception $e) {
+            print $e;
+            return [ErrorCode::$IllegalBuffer, null];
+        }
+        if ($from_corpid != $corpid) {
+            return [ErrorCode::$ValidateCorpidError, null];
+        }
+        return [0, $xml_content];
+    }
 
-	/**
-	 * 对密文进行解密
-	 * @param string $encrypted 需要解密的密文
-	 * @return string 解密得到的明文
-	 */
-	public function decrypt($encrypted, $corpid)
-	{
-
-		try {
-			//使用BASE64对需要解密的字符串进行解码
-			$ciphertext_dec = base64_decode($encrypted);
-			$module = mcrypt_module_open(MCRYPT_RIJNDAEL_128, '', MCRYPT_MODE_CBC, '');
-			$iv = substr($this->key, 0, 16);
-			mcrypt_generic_init($module, $this->key, $iv);
-
-			//解密
-			$decrypted = mdecrypt_generic($module, $ciphertext_dec);
-			mcrypt_generic_deinit($module);
-			mcrypt_module_close($module);
-		} catch (Exception $e) {
-			return array(ErrorCode::$DecryptAESError, null);
-		}
-
-
-		try {
-			//去除补位字符
-			$pkc_encoder = new PKCS7Encoder;
-			$result = $pkc_encoder->decode($decrypted);
-			//去除16位随机字符串,网络字节序和AppId
-			if (strlen($result) < 16)
-				return "";
-			$content = substr($result, 16, strlen($result));
-			$len_list = unpack("N", substr($content, 0, 4));
-			$xml_len = $len_list[1];
-			$xml_content = substr($content, 4, $xml_len);
-			$from_corpid = substr($content, $xml_len + 4);
-		} catch (Exception $e) {
-			print $e;
-			return array(ErrorCode::$IllegalBuffer, null);
-		}
-		if ($from_corpid != $corpid)
-			return array(ErrorCode::$ValidateCorpidError, null);
-		return array(0, $xml_content);
-
-	}
-
-
-	/**
-	 * 随机生成16位字符串
-	 * @return string 生成的字符串
-	 */
-	function getRandomStr()
-	{
-
-		$str = "";
-		$str_pol = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz";
-		$max = strlen($str_pol) - 1;
-		for ($i = 0; $i < 16; $i++) {
-			$str .= $str_pol[mt_rand(0, $max)];
-		}
-		return $str;
-	}
-
+    /**
+     * 生成随机字符串
+     *
+     * @return string
+     */
+    private function getRandomStr()
+    {
+        $str     = '';
+        $str_pol = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyl';
+        $max     = strlen($str_pol) - 1;
+        for ($i = 0; $i < 16; $i++) {
+            $str .= $str_pol[mt_rand(0, $max)];
+        }
+        return $str;
+    }
 }
-
-?>


### PR DESCRIPTION
使用OpenSSL替换Mcrypt，以兼容新版PHP。
使用Wampserver 3.1.3 64bit测试，PHP 5.6.35、7.0.29、7.1.16、7.2.4这4个版本下均正常运行。

根据官方文档：http://php.net/manual/zh/intro.mcrypt.php
Mcrypt扩展从 PHP 7.1.0 开始废弃；自 PHP 7.2.0 起，会移到 PECL。