### PR TITLE
Update return method

### DIFF
--- a/callback/Sample.php
+++ b/callback/Sample.php
@@ -38,7 +38,7 @@ $sEchoStr = "";
 $wxcpt = new WXBizMsgCrypt($token, $encodingAesKey, $corpId);
 $errCode = $wxcpt->VerifyURL($sVerifyMsgSig, $sVerifyTimeStamp, $sVerifyNonce, $sVerifyEchoStr, $sEchoStr);
 if ($errCode == 0) {
-    var_dump($sEchoStr);
+    echo $sEchoStr;
 	//
 	// 验证URL成功，将sEchoStr返回
 	// HttpUtils.SetResponce($sEchoStr);

--- a/callback_json/Sample.php
+++ b/callback_json/Sample.php
@@ -35,7 +35,7 @@ $wxcpt = new WXBizMsgCrypt($token, $encodingAesKey, $sReceiveId);
 $errCode = $wxcpt->VerifyURL($sVerifyMsgSig, $sVerifyTimeStamp, $sVerifyNonce, $sVerifyEchoStr, $sEchoStr);
 if ($errCode == 0) {
 	print("done VerifyURL, sEchoStr : \n");
-    var_dump($sEchoStr);
+    echo $sEchoStr;
 	//
 	// 验证URL成功，将sEchoStr返回
 	// HttpUtils.SetResponce($sEchoStr);


### PR DESCRIPTION
原有的var_dump方法返回的值会包含""",
非所要求的"原样返回明文消息内容",要想满足企业微信的验证要求，建议改为echo